### PR TITLE
Debug unbound variable in install script

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -186,7 +186,7 @@ services:
       - postgres
     volumes:
       - dbbackups:/backups
-    entrypoint: ["bash", "-lc", "while true; do TS=\\$(date -u +%Y%m%d_%H%M%S); pg_dump -Fc -f /backups/marzban_\\"$TS\\".dump && echo Backup done at \\"$TS\\"; sleep 86400; done"]
+    entrypoint: ["bash", "-lc", "while true; do TS=\$(date -u +%Y%m%d_%H%M%S); pg_dump -Fc -f /backups/marzban_\\"\$TS\\".dump && echo Backup done at \\"\$TS\\"; sleep 86400; done"]
 
   nginx:
     image: nginx:1.27-alpine


### PR DESCRIPTION
Fix 'unbound variable' error in `install.sh` by correctly escaping `$` for `$(date ...)` and `\$TS` in the `db-backup` entrypoint.

The `deploy/install.sh` script uses a here-doc to generate `docker-compose.generated.yml`. With `set -u` active, `$TS` was prematurely expanded by the shell during file generation, leading to an "unbound variable" error. The fix ensures these are passed literally to the compose file and evaluated only when the Docker container starts.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fae3a8a-8b03-4d39-ab5d-f944f995bace">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fae3a8a-8b03-4d39-ab5d-f944f995bace">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

