### PR TITLE
Fix admin login invalid credentials

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,7 @@ COPY backend /app
 
 EXPOSE 8000
 
-CMD ["python", "app/alembic_entrypoint.py"]
+# Ensure the `app` package is importable and run entrypoint as a module
+ENV PYTHONPATH=/app
+
+CMD ["python", "-m", "app.alembic_entrypoint"]

--- a/backend/app/alembic_entrypoint.py
+++ b/backend/app/alembic_entrypoint.py
@@ -2,6 +2,11 @@ import os
 import sys
 import subprocess
 
+# Ensure project root (containing the `app` package) is on sys.path when run as a script
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
 
 def run(cmd):
     import shlex


### PR DESCRIPTION
Fix `ModuleNotFoundError` in backend entrypoint to allow the backend to start and seed the admin user.

The backend container failed to start due to `ModuleNotFoundError: No module named 'app'`. This occurred because the `alembic_entrypoint.py` was executed as a script, preventing Python from correctly resolving imports within the `app` package. The changes ensure the `app` package is on `sys.path` and the entrypoint is run as a module, resolving the import issue and allowing the admin user seeding logic to execute.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3305602-8e53-43d9-8b33-19f350554448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3305602-8e53-43d9-8b33-19f350554448">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

