### PR TITLE
Fix missing backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,10 +8,11 @@ pydantic-settings==2.4.0
 python-jose==3.3.0
 passlib==1.7.4
 argon2-cffi==23.1.0
-bcrypt==4.1.3
+bcrypt==4.0.1
 redis==5.0.7
 python-multipart==0.0.9
 boto3==1.34.162
 psutil==6.0.0
 slowapi==0.1.7
 orjson==3.10.7
+email-validator==2.2.0


### PR DESCRIPTION
Add `email-validator` and pin `bcrypt` to `4.0.1` to resolve backend startup errors.

The `ImportError: email-validator is not installed` was fixed by adding the dependency. The `AttributeError: module 'bcrypt' has no attribute '__about__'` occurred due to a compatibility issue between `passlib==1.7.4` and `bcrypt==4.1.3` on Python 3.12, which is resolved by pinning `bcrypt` to `4.0.1`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d65636fd-25bc-4e77-a8ad-f61a3eef29c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d65636fd-25bc-4e77-a8ad-f61a3eef29c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

