### PR TITLE
Fix backend login rate limiting error

### DIFF
--- a/backend/app/api/routes/configs.py
+++ b/backend/app/api/routes/configs.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, Query
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 from typing import List
 from fastapi.responses import FileResponse
@@ -22,7 +22,7 @@ def list_configs(db: Session = Depends(get_db), _: User = Depends(require_roles(
 
 @router.post("/configs", response_model=SignedURL)
 @limiter.limit("10/minute")
-async def upload_config(title: str, file: UploadFile = File(...), db: Session = Depends(get_db), current_user: User = Depends(require_roles(["admin", "operator"]))):
+async def upload_config(request: Request, title: str, file: UploadFile = File(...), db: Session = Depends(get_db), current_user: User = Depends(require_roles(["admin", "operator"]))):
     content = await file.read()
     file_path = save_file(file.filename, content)
     cfg = Config(title=title, file_path=file_path, uploaded_by=current_user.id)


### PR DESCRIPTION
Add `request: Request` parameter to rate-limited endpoints to resolve `slowapi` exceptions.

The `slowapi` library, used for rate limiting, requires the decorated function to accept a `request` (or `websocket`) argument. Without this argument, the application fails to start with an `Exception: No "request" or "websocket" argument on function ...`. This PR adds the necessary `request: Request` parameter and `Request` import to all identified rate-limited endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-eee01f46-1880-4c7d-8663-0c8fafa005f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eee01f46-1880-4c7d-8663-0c8fafa005f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

