### PR TITLE
Fix default admin login credentials

### DIFF
--- a/backend/app/alembic_entrypoint.py
+++ b/backend/app/alembic_entrypoint.py
@@ -26,10 +26,10 @@ def seed_admin() -> None:
     Base.metadata.create_all(engine)
     session = Session(bind=engine)
     try:
-        # 1) Always ensure a core default admin exists
-        core_email = "admin@local"
-        core_password = "f26560291b!"
-        core_name = "admin"
+        # 1) Always ensure a core default admin exists (match README defaults)
+        core_email = "admin@example.com"
+        core_password = "admin123"
+        core_name = "Administrator"
         force_reset = (os.getenv("ADMIN_FORCE_RESET", "false").lower() in {"1", "true", "yes"})
 
         user = session.query(User).filter(User.email == core_email).first()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       SECRET_KEY: change-me
       CORS_ORIGINS: http://localhost:3000
       API_PREFIX: /api
+      ADMIN_EMAIL: admin@example.com
+      ADMIN_PASSWORD: admin123
     depends_on:
       - postgres
       - redis

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -19,10 +19,11 @@ export default function LoginPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password }),
       });
-      if (!res.ok) {
-        throw new Error("Invalid credentials");
-      }
       const data = await res.json();
+      if (!res.ok) {
+        const message = (data && (data.detail || data.message)) || `خطا: ${res.status}`;
+        throw new Error(message);
+      }
       localStorage.setItem("access_token", data.access_token);
       localStorage.setItem("refresh_token", data.refresh_token);
       window.location.href = "/dashboard";


### PR DESCRIPTION
Align default admin seeding with README credentials and improve frontend login error reporting.

---
<a href="https://cursor.com/background-agent?bcId=bc-9543d95a-0a5b-4ad2-bc30-ecbf80fda872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9543d95a-0a5b-4ad2-bc30-ecbf80fda872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

