### PR TITLE
Fix default admin login fetch error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     depends_on:
       - backend
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000/api
+      NEXT_PUBLIC_API_BASE_URL: /api
     ports:
       - "3000:3000"
 

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -14,7 +14,7 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000/api";
+      const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
       const res = await fetch(apiUrl + "/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,5 @@
 export async function apiFetch(path: string, init: RequestInit = {}) {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000/api";
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
   const headers = new Headers(init.headers);
   headers.set("Content-Type", headers.get("Content-Type") || "application/json");
   const token = typeof window !== "undefined" ? localStorage.getItem("access_token") : null;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:8000/api/:path*",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Update API base URL to a relative path (`/api`) and add Next.js rewrites to resolve "Failed to fetch" errors during login.

The "Failed to fetch" error was caused by the frontend directly calling the backend API at `http://localhost:8000/api`, leading to CORS or mixed-content issues. By using a relative `/api` path and configuring Next.js rewrites, all API requests are proxied through the frontend's origin, eliminating cross-origin problems in both development and production environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-3acede83-4b19-4814-8955-af89e80ad30e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3acede83-4b19-4814-8955-af89e80ad30e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

